### PR TITLE
Fix migration information in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin requires `django CMS` 2.4 or higher to be properly installed.
 
 * In your projects `virtualenv`_, run ``pip install djangocms-style``.
 * Add ``'djangocms_style'`` to your ``INSTALLED_APPS`` setting.
-* If using Django 1.7 add ``'djangocms_syle': 'djangocms_syle.migrations_django',``
+* If using Django 1.7 add ``'djangocms_style': 'djangocms_style.migrations_django',``
   to ``MIGRATION_MODULES``  (or define ``MIGRATION_MODULES`` if it does not exists);
   when django CMS 3.1 will be released, migrations for Django 1.7 will be moved
   to the standard location and the south-style ones to ``south_migrations``.


### PR DESCRIPTION
Currently the MIGRATION_MODULES information in the README contains a small typo.