### PR TITLE
Add __str__/Python 3-compatibility via six

### DIFF
--- a/djangocms_style/models.py
+++ b/djangocms_style/models.py
@@ -1,5 +1,6 @@
 from cms.models import CMSPlugin
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
@@ -12,6 +13,7 @@ CLASS_NAMES = getattr(settings, "CMS_STYLE_NAMES", (
 )
 
 
+@python_2_unicode_compatible
 class Style(CMSPlugin):
     """
     A CSS Style Plugin
@@ -50,7 +52,7 @@ class Style(CMSPlugin):
         help_text=_('Comma separated list of additional classes to apply to tag_type')
     )
 
-    def __unicode__(self):
+    def __str__(self):
         display = self.get_class_name_display() or self.tag_type or u''
         return u"%s" % display
 
@@ -80,4 +82,3 @@ class Style(CMSPlugin):
             # Removes any extra spaces
             return ' '.join((html_class.strip() for html_class in self.additional_classes.split(',')))
         return ''
-

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from djangocms_style import __version__
 
 
 INSTALL_REQUIRES = [
-
 ]
 
 CLASSIFIERS = [
@@ -21,6 +20,7 @@ CLASSIFIERS = [
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Message Boards',
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.4',
 ]
 
 setup(


### PR DESCRIPTION
This renames the __unicode__ model method to __str__ and adds the @python_2_unicode_compatible class decorator to support Python 3. Since the plugin should stay compatible with django CMS 2.x I've added six as a dependency and not used the compatibility layer provided by django CMS itself.

I've tested it with a Django 1.6 project using Python 2.7 and Python 3.4.