### PR TITLE
Release version 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.0.0 (unreleased)
+2.0.0 (2016-11-15)
 ==================
 
 * Backwards incompatible changes

--- a/djangocms_style/__init__.py
+++ b/djangocms_style/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.7.0'
+__version__ = '2.0.0'


### PR DESCRIPTION
* Backwards incompatible changes
    * Moved template from ``templates/cms/plugins/style.html`` to
      ``templates/djangocms_style/default/style.html``
    * Added setting ``DJANGOCMS_STYLE_TEMPLATES``
    * Added setting ``DJANGOCMS_STYLE_CHOICES`` that will replace
      ``CMS_STYLE_NAMES``
    * Added setting ``DJANGOCMS_STYLE_TAGS`` that will replace
      ``CMS_STYLE_TAG_TYPES``
    * Removed Django < 1.8 support
    * Removed ``alt`` attribute and migrated data to Filer
* Added additional fields such as ``label``, ``id_name`` and additional
  ``attributes``
* Updated ``README.txt``
* Updated translations