### PR TITLE
Small adaptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
   - TOX_ENV=py27-latest
   - TOX_ENV=py34-latest
   # Django 1.8
-  - TOX_ENV=py34-dj18-cms33
-  - TOX_ENV=py34-dj18-cms32
+  - TOX_ENV=py27-dj18-cms34
   - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py27-dj18-cms32
+  - TOX_ENV=py34-dj18-cms34
+  - TOX_ENV=py34-dj18-cms33
   # Django 1.9
-  - TOX_ENV=py34-dj19-cms33
-  - TOX_ENV=py34-dj19-cms32
+  - TOX_ENV=py27-dj19-cms34
   - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py27-dj19-cms32
+  - TOX_ENV=py34-dj19-cms34
+  - TOX_ENV=py34-dj19-cms33
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,16 @@
 Changelog
 =========
 
-(unreleased)
-============
 
-* Prevent changes to `DJANGOCMS_STYLE_XXX` settings from requiring new
+2.0.1 (unreleased)
+==================
+
+* Prevent changes to ``DJANGOCMS_STYLE_XXX`` settings from requiring new
   migrations
+* Changed naming of ``Aldryn`` to ``Divio Cloud``
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.4 and dropped 3.2
+
 
 2.0.0 (2016-11-15)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ django CMS Style
 that allows you to create a HTML container containing classes, styles, ids
 and other attributes definable through the plugins settings.
 
-This addon is compatible with `Aldryn <http://aldryn.com>`_ and is also available on the
+This addon is compatible with `Divio Cloid <http://divio.com>`_ and is also available on the
 `django CMS Marketplace <https://marketplace.django-cms.org/en/addons/browse/djangocms-style/>`_
 for easy installation.
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ django CMS Style
 that allows you to create a HTML container containing classes, styles, ids
 and other attributes definable through the plugins settings.
 
-This addon is compatible with `Divio Cloid <http://divio.com>`_ and is also available on the
+This addon is compatible with `Divio Cloud <http://divio.com>`_ and is also available on the
 `django CMS Marketplace <https://marketplace.django-cms.org/en/addons/browse/djangocms-style/>`_
 for easy installation.
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     py{34,27}-latest
-    py{34,27}-dj18-cms{33,32}
-    py{34,27}-dj19-cms{33,32}
+    py{34,27}-dj18-cms{34,33}
+    py{34,27}-dj19-cms{34,33}
 
 skip_missing_interpreters=True
 
@@ -14,8 +14,8 @@ deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     latest: django-cms
-    cms32: django-cms>=3.2,<3.3
     cms33: django-cms>=3.3,<3.4
+    cms34: django-cms>=3.4,<3.5
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
Update testing infrastructure to use django CMS 3.4 and drop 3.2 to keep the matrix small