### PR TITLE
initial Django 2.0 support

### DIFF
--- a/djangocms_style/migrations/0001_initial.py
+++ b/djangocms_style/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Style',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, related_name='+', parent_link=True, to='cms.CMSPlugin', primary_key=True)),
+                ('cmsplugin_ptr', models.OneToOneField(serialize=False, related_name='+', parent_link=True, to='cms.CMSPlugin', primary_key=True, on_delete=models.CASCADE)),
                 ('class_name', models.CharField(blank=True, max_length=50, choices=CLASS_CHOICES, verbose_name='class name', null=True, default=CLASS_CHOICES[0][0])),
                 ('tag_type', models.CharField(verbose_name='tag Type', default=TAG_CHOICES[0][0], max_length=50, choices=TAG_CHOICES)),
                 ('padding_left', models.SmallIntegerField(verbose_name='padding left', blank=True, null=True)),

--- a/djangocms_style/models.py
+++ b/djangocms_style/models.py
@@ -158,6 +158,7 @@ class Style(CMSPlugin):
         CMSPlugin,
         related_name='%(app_label)s_%(class)s',
         parent_link=True,
+        on_delete=models.CASCADE,
     )
 
     def __str__(self):


### PR DESCRIPTION
Squashing some incompatibilities between Django 1.11 and 2.0.

django-cms is not Django 2.0 ready yet, but I'm trying to get various plugins and dependencies compatible to make it easier for the whole ecosystem to work on 2.0.x eventually.