### PR TITLE
Add support for new Django versions 1.11/2.0/2.1 and drop for 1.8/1.9/1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 dist/
 build/
 htmlcov/
+local.sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,15 @@ sudo: false
 
 env:
   - TOX_ENV=flake8
-  - TOX_ENV=py27-latest
-  - TOX_ENV=py34-latest
-  # Django 1.8
-  - TOX_ENV=py27-dj18-cms34
-  - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py34-dj18-cms34
-  - TOX_ENV=py34-dj18-cms33
-  # Django 1.9
-  - TOX_ENV=py27-dj19-cms34
-  - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py34-dj19-cms34
-  - TOX_ENV=py34-dj19-cms33
+  # Django 1.11
+  - TOX_ENV=py27-dj111-cms35
+  - TOX_ENV=py35-dj111-cms35
+  # Django 2.0
+  - TOX_ENV=py35-dj20-cms35
+  - TOX_ENV=py35-dj20-cms40
+  # Django 2.1
+  - TOX_ENV=py35-dj21-cms35
+  - TOX_ENV=py35-dj21-cms40
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,14 @@
 Changelog
 =========
 
-2.0.3 (unreleased)
+2.1.0 (unreleased)
 ==================
 
 * Fixed a validation issue with attributes
+* Added support for Django 1.11, 2.0 and 2.1
+* Removed support for Django 1.8, 1.9, 1.10
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.5 and 4.0
 
 
 2.0.2 (2017-03-07)

--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,8 @@ Documentation
 See ``REQUIREMENTS`` in the `setup.py <https://github.com/divio/djangocms-style/blob/master/setup.py>`_
 file for additional dependencies:
 
-* Python 2.7, 3.3 or higher
-* Django 1.8 or higher
+* Python 2.7, 3.4 or higher
+* Django 1.11 or higher
 
 
 Installation

--- a/djangocms_style/cms_plugins.py
+++ b/djangocms_style/cms_plugins.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.utils.translation import ugettext_lazy as _
 
-from cms.plugin_pool import plugin_pool
 from cms.plugin_base import CMSPluginBase
+from cms.plugin_pool import plugin_pool
 
 from .models import Style
 

--- a/djangocms_style/migrations/0001_initial.py
+++ b/djangocms_style/migrations/0001_initial.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import django.db.models.deletion
 from django.db import models, migrations
 from djangocms_style.models import CLASS_CHOICES, TAG_CHOICES
 
@@ -14,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Style',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, related_name='+', parent_link=True, to='cms.CMSPlugin', primary_key=True)),
+                ('cmsplugin_ptr', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, serialize=False, related_name='+', parent_link=True, to='cms.CMSPlugin', primary_key=True)),
                 ('class_name', models.CharField(blank=True, max_length=50, choices=CLASS_CHOICES, verbose_name='class name', null=True, default=CLASS_CHOICES[0][0])),
                 ('tag_type', models.CharField(verbose_name='tag Type', default=TAG_CHOICES[0][0], max_length=50, choices=TAG_CHOICES)),
                 ('padding_left', models.SmallIntegerField(verbose_name='padding left', blank=True, null=True)),

--- a/djangocms_style/models.py
+++ b/djangocms_style/models.py
@@ -8,17 +8,16 @@ from __future__ import unicode_literals
 import re
 import warnings
 
-from django.db import models
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db import models
 from django.utils.datastructures import OrderedSet
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.six import string_types
-from django.utils.translation import ugettext, ugettext_lazy as _
-
-from djangocms_attributes_field.fields import AttributesField
+from django.utils.translation import ugettext_lazy as _
 
 from cms.models import CMSPlugin
+
+from djangocms_attributes_field.fields import AttributesField
 
 
 if hasattr(settings, 'CMS_STYLE_NAMES'):
@@ -46,6 +45,7 @@ else:
 
 CLASS_NAME_FORMAT = re.compile(r'^\w[\w_-]*$')
 TAG_TYPE_FORMAT = re.compile(r'\w[\w\d]*$')
+
 
 # Add additional choices through the ``settings.py``.
 def get_templates():
@@ -95,7 +95,7 @@ class Style(CMSPlugin):
         blank=True,
         max_length=255,
         help_text=_('Additional comma separated list of classes '
-            'to be added to the element e.g. "row, column-12, clearfix".'),
+                    'to be added to the element e.g. "row, column-12, clearfix".'),
     )
     id_name = models.CharField(
         verbose_name=_('ID name'),
@@ -158,6 +158,7 @@ class Style(CMSPlugin):
         CMSPlugin,
         related_name='%(app_label)s_%(class)s',
         parent_link=True,
+        on_delete=models.CASCADE,
     )
 
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,9 @@ from setuptools import find_packages, setup
 
 from djangocms_style import __version__
 
-
 REQUIREMENTS = [
-    'django-cms>=3.2.0',
-    'djangocms-attributes-field>=0.1.1',
+    'django-cms>=3.4.5',
+    'djangocms-attributes-field>=0.4.0',
 ]
 
 
@@ -24,6 +23,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,9 +13,11 @@ HELPER_SETTINGS = {
     'LANGUAGE_CODE': 'en',
 }
 
+
 def run():
     from djangocms_helper import runner
     runner.cms('djangocms_style')
+
 
 if __name__ == '__main__':
     run()

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
     flake8
-    py{34,27}-latest
-    py{34,27}-dj18-cms{34,33}
-    py{34,27}-dj19-cms{34,33}
+    py{36,35,34,27}-dj111-cms{35,34}
+    py{36,35,34}-dj20-cms{40,35}
+    py{36,35}-dj21-cms{40,35}
 
 skip_missing_interpreters=True
 
@@ -11,11 +11,12 @@ skip_missing_interpreters=True
 [testenv]
 deps =
     -r{toxinidir}/tests/requirements.txt
-    dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
-    latest: django-cms
-    cms33: django-cms>=3.3,<3.4
+    dj111: Django>=1.11,<2.0
+    dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     cms34: django-cms>=3.4,<3.5
+    cms35: django-cms>=3.5,<3.6
+    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
Based on #41 