### PR TITLE
Bumped version to 2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.3.0 (unreleased)
+2.3.0 (2020-01-29)
 ==================
 
 * Added support for Django 3.0

--- a/djangocms_style/__init__.py
+++ b/djangocms_style/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.2.0'
+__version__ = '2.3.0'


### PR DESCRIPTION
* Added support for Django 3.0
* Deprecated old ``CMS_STYLE_NAMES`` setting
* Deprecated old ``CMS_STYLE_TAG_TYPES`` setting
* Added further tests to raise coverage
* Fixed smaller issues found during testing
