### PR TITLE
chore: Remove DEFAULT_AUTO_FIELD from test settings

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -75,6 +75,4 @@ LANGUAGE_CODE = "en"
 
 ROOT_URLCONF = "tests.urls"
 
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
 CMS_CONFIRM_VERSION4 = True


### PR DESCRIPTION
Removed the DEFAULT_AUTO_FIELD setting.

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
